### PR TITLE
Add controller namespacing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphiti-rails (0.2.0)
+    graphiti-rails (0.2.1)
       graphiti (~> 1.2)
       rails (>= 5.0)
       rescue_registry (~> 0.2.1)
@@ -123,10 +123,10 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
     mimemagic (0.3.3)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nio4r (2.3.1)
+    nio4r (2.5.2)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
@@ -163,7 +163,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
-    rescue_registry (0.2.1)
+    rescue_registry (0.2.2)
       activesupport (>= 5.0)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
@@ -202,9 +202,9 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.4)
     yard (0.9.19)
 
 PLATFORMS
@@ -225,4 +225,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/generators/graphiti/generator_mixin.rb
+++ b/lib/generators/graphiti/generator_mixin.rb
@@ -27,7 +27,7 @@ module Graphiti
 
     def namespace_controllers?
       @namespace_controllers ||= begin
-        unless graphiti_config["namespace-controllers"] || !@options["namespace-controllers"]
+        if graphiti_config["namespace-controllers"].blank?
           update_config!("namespace-controllers" => @options["namespace-controllers"] )
         end
         graphiti_config["namespace-controllers"]
@@ -42,12 +42,14 @@ module Graphiti
       clean_namespace.split("/")
     end
 
-    def controller_class_namespace
-      output = ""
-      controller_namespaces_path.each do |beep|
-        output += beep.capitalize + "::"
+    def controller_modules
+      if namespace_controllers?
+        output = ""
+        controller_namespaces_path.each do |mod|
+          output += mod.capitalize + "::"
+        end
+        output
       end
-      output
     end
 
     def actions

--- a/lib/generators/graphiti/generator_mixin.rb
+++ b/lib/generators/graphiti/generator_mixin.rb
@@ -25,6 +25,22 @@ module Graphiti
       end
     end
 
+    def clean_namespace
+      api_namespace.gsub(/^\/|\/$/,"")
+    end
+
+    def controller_namespaces_path
+      clean_namespace.split("/")
+    end
+
+    def controller_class_namespace
+      output = ""
+      controller_namespaces_path.each do |beep|
+        output += beep.capitalize + "::"
+      end
+      output
+    end
+
     def actions
       @options["actions"] || %w[index show create update destroy]
     end

--- a/lib/generators/graphiti/generator_mixin.rb
+++ b/lib/generators/graphiti/generator_mixin.rb
@@ -25,6 +25,15 @@ module Graphiti
       end
     end
 
+    def namespace_controllers?
+      @namespace_controllers ||= begin
+        unless graphiti_config["namespace-controllers"] || !@options["namespace-controllers"]
+          update_config!("namespace-controllers" => @options["namespace-controllers"] )
+        end
+        graphiti_config["namespace-controllers"]
+      end
+    end
+
     def clean_namespace
       api_namespace.gsub(/^\/|\/$/,"")
     end

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -52,20 +52,12 @@ module Graphiti
       end
 
       insert_into_file "config/routes.rb", after: "Rails.application.routes.draw do\n" do
-        if defined?(VandalUi)
           <<-STR
   scope path: ApplicationResource.endpoint_namespace, defaults: { format: :jsonapi } do
-    mount VandalUi::Engine, at: '/vandal'
-    # your routes go here
+    # your routes go here\
+#{"\n\t\tmount VandalUi::Engine, at: '/vandal'" if defined?(VandalUi)}
   end
           STR
-        else
-          <<-STR
-  scope path: ApplicationResource.endpoint_namespace, defaults: { format: :jsonapi } do
-    # your routes go here
-  end
-          STR
-        end
       end
     end
 

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -23,12 +23,21 @@ module Graphiti
       to = File.join("app/resources", "application_resource.rb")
       template("application_resource.rb.erb", to)
 
-      inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::API\n" do
-        app_controller_code
-      end
+      if namespace_controllers?
+        to = File.join(
+          "app/controllers",
+          (controller_namespaces_path if namespace_controllers?),
+          "graphiti_controller.rb"
+        )
+        template("graphiti_controller.rb.erb", to)
+      else
+        inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::API\n" do
+          app_controller_code
+        end
 
-      inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::Base\n" do
-        app_controller_code
+        inject_into_file "app/controllers/application_controller.rb", after: "class ApplicationController < ActionController::Base\n" do
+          app_controller_code
+        end
       end
 
       inject_into_file "config/application.rb", after: "Rails::Application\n" do

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -12,7 +12,7 @@ module Graphiti
       aliases: ["-c"],
       desc: "Generate without documentation comments"
 
-    class_option :'namespace_controllers',
+    class_option :'namespace-controllers',
       type: :boolean,
       default: false,
       aliases: ["-n"],
@@ -73,6 +73,10 @@ module Graphiti
 
     def omit_comments?
       @options["omit-comments"]
+    end
+
+    def namespace_controllers?
+      @options["namespace-controllers"]
     end
 
     def app_controller_code

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -68,10 +68,6 @@ module Graphiti
       @options["omit-comments"]
     end
 
-    def namespace_controllers?
-      @options["namespace-controllers"]
-    end
-
     def app_controller_code
       str = ""
       if defined?(::Responders)

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -12,6 +12,12 @@ module Graphiti
       aliases: ["-c"],
       desc: "Generate without documentation comments"
 
+    class_option :'namespace_controllers',
+      type: :boolean,
+      default: false,
+      aliases: ["-n"],
+      desc: "Generated controllers will be namespaced"
+
     desc "This generator boostraps graphiti"
     def install
       to = File.join("app/resources", "application_resource.rb")

--- a/lib/generators/graphiti/install_generator.rb
+++ b/lib/generators/graphiti/install_generator.rb
@@ -53,7 +53,8 @@ module Graphiti
 
       insert_into_file "config/routes.rb", after: "Rails.application.routes.draw do\n" do
           <<-STR
-  scope path: ApplicationResource.endpoint_namespace, defaults: { format: :jsonapi } do
+  scope path: ApplicationResource.endpoint_namespace, defaults: { format: :jsonapi }\
+#{", module: \"#{clean_namespace}\"" if namespace_controllers?} do
     # your routes go here\
 #{"\n\t\tmount VandalUi::Engine, at: '/vandal'" if defined?(VandalUi)}
   end

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -129,7 +129,7 @@ module Graphiti
     end
 
     def generate_controller
-      to = File.join("app/controllers", class_path, "#{file_name.pluralize}_controller.rb")
+      to = File.join("app/controllers", namespace_controllers? ? controller_namespaces_path : class_path, "#{file_name.pluralize}_controller.rb")
       template("controller.rb.erb", to)
     end
 

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -35,9 +35,7 @@ module Graphiti
     desc "This generator creates a resource file at app/resources, as well as corresponding controller/specs/route/etc"
     def generate_all
       generate_model
-      unless skip_controller?
-        generate_controller
-      end
+      generate_controller unless skip_controller?
       generate_application_resource unless application_resource_defined?
       generate_route
       generate_resource
@@ -106,7 +104,8 @@ module Graphiti
       end
       if attributes_class.table_exists?
         return attributes_class.columns.map do |c|
-          OpenStruct.new({name: c.name.to_sym, type: c.type == :text ? :string : c.type})
+          column_type = (c.type == :text ? :string : c.type)
+          OpenStruct.new(name: c.name.to_sym, type: column_type )
         end
       else
         raise "#{attributes_class} table must exist. Please run migrations."

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -106,7 +106,7 @@ module Graphiti
       end
       if attributes_class.table_exists?
         return attributes_class.columns.map do |c|
-          OpenStruct.new({name: c.name.to_sym, type: c.type})
+          OpenStruct.new({name: c.name.to_sym, type: c.type == :text ? :string : c.type})
         end
       else
         raise "#{attributes_class} table must exist. Please run migrations."

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -26,6 +26,12 @@ module Graphiti
       aliases: ["--model", "-m"],
       desc: "Specify to use attributes from a particular model"
 
+    class_option :'skip-controller',
+      type: :boolean,
+      default: false,
+      aliases: ["--skip-controller"],
+      desc: "Skip the controller generator"
+
     desc "This generator creates a resource file at app/resources, as well as corresponding controller/specs/route/etc"
     def generate_all
       generate_model
@@ -62,6 +68,10 @@ module Graphiti
 
     def omit_comments?
       @options["omit-comments"]
+    end
+
+    def skip_controller?
+      @options["skip-controller"]
     end
 
     def attributes_class

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -35,7 +35,9 @@ module Graphiti
     desc "This generator creates a resource file at app/resources, as well as corresponding controller/specs/route/etc"
     def generate_all
       generate_model
-      generate_controller
+      unless skip_controller?
+        generate_controller
+      end
       generate_application_resource unless application_resource_defined?
       generate_route
       generate_resource

--- a/lib/generators/graphiti/templates/controller.rb.erb
+++ b/lib/generators/graphiti/templates/controller.rb.erb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= controller_class_namespace if namespace_controllers?%><%= model_klass.name.pluralize %>Controller < ApplicationController
+class <%= controller_modules %><%= model_klass.name.pluralize %>Controller < <%= controller_modules %><%= namespace_controllers? ? "GraphitiController" : "ApplicationController" %>
   <%- if actions?('index') -%>
   def index
     <%= file_name.pluralize %> = <%= resource_klass %>.all(params)

--- a/lib/generators/graphiti/templates/controller.rb.erb
+++ b/lib/generators/graphiti/templates/controller.rb.erb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= model_klass.name.pluralize %>Controller < ApplicationController
+class <%= controller_class_namespace if namespace_controllers?%><%= model_klass.name.pluralize %>Controller < ApplicationController
   <%- if actions?('index') -%>
   def index
     <%= file_name.pluralize %> = <%= resource_klass %>.all(params)

--- a/lib/generators/graphiti/templates/graphiti_controller.rb.erb
+++ b/lib/generators/graphiti/templates/graphiti_controller.rb.erb
@@ -1,0 +1,3 @@
+class <%= controller_modules%>GraphitiController < ActionController::<%= Rails.application.config.api_only ? "API" : "Base" %>
+  include Graphiti::Rails::Responders
+end


### PR DESCRIPTION
Ultimately, this PR is meant to make adding Graphiti-Rails to an existing app easier.

**Issues:**
- Default behavior of `graphiti:resource` is to overwrite a model's controller file
  - There is no option to skip generating the controller
- Default behavior of `graphiti:install` adds `include Graphiti::Rails::Responders` to `application_controller.rb`. This sets `responds_to` formats to `:json`, `:jsonapi`, and `:xml` for all descendent controllers of `ApplicationController`
  - API endpoints often have a different set of concerns than the rest of an existing application. For example, if you use Devise in your existing application, then set the `responds_to` formats in ApplicationController as above, Devise defers to already set formats and does not add `:html`. This results in Devise routes raising an UnknownFormat error.

**Changes:**
- Add a flag to `graphiti:install` to setup Graphiti to namespace subsequently generated resources.
  - Record this setting in `.graphiticfg.yml`
  - Subsequently generated resources will have new controllers which inherit from a new GraphitiController (which declares the `respond_to` formats
- I've added a flag, `--skip-controller`, to `graphiti:resource`.
  - If you decide not to namespace the Graphiti controllers and you're generating resources for an existing app, this skips generating the controller so your pre-existing controller logic isn't overwritten.

**To test:**

1. `git clone git@github.com:LoganDSPrice/graphiti_photogram_template.git`
1. `git checkout initial-state-for-testing-generators`
    - This is generated from the Photogram template on the Ideas tool. It also has a `dev:prime` task
1. `bin/setup`
1. `rails dev:prime`
1. `rails generate graphiti:install --namespace-controllers`
1. When prompted to enter a namespace, just hit `return` without entering in a namespace
1. `rake vandal:install`
1. `rails generate graphiti:resource comment -m=comment`
1. `rails generate graphiti:resource follow_request -m=follow_request`
1. `rails generate graphiti:resource like -m=like`
1. `rails generate graphiti:resource photo -m=photo`
1. `rails generate graphiti:resource user -m=user`
1. `rails server`
1. Navigate to: 
    - http://localhost:3000/api/v1/comments
    - http://localhost:3000/api/v1/follow_requests
    - http://localhost:3000/api/v1/likes
    - http://localhost:3000/api/v1/photos
    - http://localhost:3000/api/v1/users
    - http://localhost:3000/api/v1/vandal
    
